### PR TITLE
Add alpha_soil parameter to render for slope inclination (v0.2.0)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,13 @@
 
 We started keeping track of changes in the `NEWS.md` file after version 0.1.0.
 
+# PlantViz 0.2.0 (2026-06-10)
+
+* Add `alpha_soil` keyword argument to `render` to rotate the camera by the
+  soil slope inclination angle (in radians, rotation around X axis), so the XY
+  plane no longer appears horizontal when the ground surface is tilted.
+* Update dependency on PlantRayTracer to v0.2.0.
+
 # PlantViz 0.1.1 (2026-01-14)
 
 * Update dependencies and make sure it works on Julia 1.12

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "PlantViz"
 uuid = "358bd95d-d12c-439f-94b7-04b17e500c7f"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Alejandro Morales Sierra <alejandro.moralessierra@wur.nl> and contributors"]
 
 [deps]
@@ -20,6 +20,6 @@ GeometryBasics = "0.5.10"
 LinearAlgebra = "1.11"
 Makie = "0.24.6"
 PlantGeomPrimitives = "0.1.1"
-PlantRayTracer = "0.1.1"
+PlantRayTracer = "0.2.0"
 Unrolled = "0.1.5"
 julia = "1.12"

--- a/src/Render.jl
+++ b/src/Render.jl
@@ -39,11 +39,17 @@ function render(
     wireframe::Bool = false,
     axes::Bool = true,
     size = (1920, 1080),
+    alpha_soil::Real = 0,
     kwargs...,
 )
     fig = Makie.Figure(size = size)
     lscene = Makie.LScene(fig[1, 1], show_axis = axes)
     Makie.cam3d!(lscene; clipping_mode = :adaptive)
+    if alpha_soil != 0
+        new_up = Makie.Vec3f(0, -sin(alpha_soil), cos(alpha_soil))
+        cam = Makie.cameracontrols(lscene)
+        Makie.update_cam!(lscene.scene, cam.eyeposition[], cam.lookat[], new_up)
+    end
     Makie.mesh!(lscene, m, color = color; kwargs...)
     scene_additions!(m, normals, wireframe)
     fig
@@ -60,22 +66,26 @@ function render!(
 end
 
 """
-    render(mesh::Mesh; normals::Bool = false, wireframe::Bool = false, kwargs...)
+    render(mesh::Mesh; normals::Bool = false, wireframe::Bool = false, alpha_soil::Real = 0, kwargs...)
 
 Render a `Mesh` object. This will create a new visualization (see
 Documentation for details). `normals = true` will draw arrows in the direction
 of the normal vector for each triangle in the mesh, `wireframe = true` will draw
-the edges of each triangle with black lines. Keyword arguments are passed to
-`Makie.mesh()`. The actual color of each triangle depends on the illumination of the scene
-but it is possible to turn this off by passing `shading = false`. This will use the exact
-colors specified in the `Scene` object.
+the edges of each triangle with black lines. `alpha_soil` is the soil slope
+inclination angle in radians (default `0`): when non-zero, the camera is rotated
+around the X axis by this angle so that the XY plane no longer appears horizontal.
+Keyword arguments are passed to `Makie.mesh()`. The actual color of each triangle
+depends on the illumination of the scene but it is possible to turn this off by
+passing `shading = false`. This will use the exact colors specified in the `Scene`
+object.
 """
-function render(mesh::PGP.Mesh; normals::Bool = false, wireframe::Bool = false, kwargs...)
+function render(mesh::PGP.Mesh; normals::Bool = false, wireframe::Bool = false, alpha_soil::Real = 0, kwargs...)
     render(
         PGP.GLMesh(mesh);
         color = repeat(colors(mesh), inner = 3),
         normals = normals,
         wireframe = wireframe,
+        alpha_soil = alpha_soil,
         kwargs...,
     )
 end

--- a/test/test_primitives.jl
+++ b/test/test_primitives.jl
@@ -13,6 +13,8 @@ t = Triangle(length = 2.0f0, width = 2.0f0)
 add_property!(t, :colors, RGB(1, 0, 0))
 render(t, wireframe = true, normals = true)
 
+# Test that we can rotate the camera
+render(t, wireframe = true, normals = true,alpha_soil = pi/8)
 
 # Rectangle
 r = Rectangle(length = 2.0, width = 1.0);


### PR DESCRIPTION
## Summary

- Adds `alpha_soil::Real = 0` keyword argument to `render(mesh::PGP.Mesh; ...)` and
  the underlying `render(m::GeometryBasics.Mesh; ...)`. When non-zero, the camera is
  rotated around the X axis by `alpha_soil` radians so the XY plane no longer appears
  horizontal, matching scenes where the ground surface has a slope inclination.
- Updates the docstring for `render(mesh::Mesh; ...)` to document the new argument and its units.
- Adds a basic smoke test for the new parameter in `test/test_primitives.jl`.
- Bumps package version to `0.2.0` and updates the `PlantRayTracer` compat bound to `0.2.0`.

## Test plan

- [ ] Existing tests pass (`runtests.jl`)
- [ ] New smoke test (`render(t, alpha_soil = pi/8)`) renders without error
- [ ] Visually confirm that a non-zero `alpha_soil` tilts the XY plane in the rendered scene